### PR TITLE
feat(uiux): improve screen reader labels on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Open [http://localhost:3000](http://localhost:3000).
 - Loading, empty, and error states are treated as first-class layout states to avoid abrupt page shifts.
 - Interactive elements include visible focus rings and semantic headings to support keyboard and screen-reader use.
 
+## Screen reader labeling guidelines
+
+- Prefer visible text as the accessible name, then add hidden context or `aria-label` only when repeated labels would otherwise be ambiguous.
+- Pair dashboard cards, panels, and list items with `aria-labelledby` and `aria-describedby` so values, helper copy, and status chips are announced with the right context.
+- Give repeated controls unique names, especially workflow links and state buttons. Include position or state only when it helps distinguish similar items.
+- Status chips should describe the thing they qualify, such as wallet security, slot availability, or workflow state. Avoid announcing decorative helper text twice.
+- Use `aria-live="polite"` with `aria-atomic="true"` for dynamic dashboard values such as balances, booking counts, sync state, and slot availability.
+- Mark decorative icons, separators, skeleton blocks, and repeated visual CTAs with `aria-hidden="true"` when nearby labels already communicate the same action.
+- Security assumption: these changes are UI-only accessible-name and description updates. They do not alter wallet connection logic, transaction handling, API calls, authorization, or persisted user data.
+
 ## UX copywriting pass (FE-DESIGN-030)
 
 The dashboard copy was updated to improve clarity, trust, and scan speed:

--- a/src/app/components/dashboard-shell.tsx
+++ b/src/app/components/dashboard-shell.tsx
@@ -8,9 +8,16 @@ export function DashboardShell({ children }: DashboardShellProps) {
   return (
     <div className="app-shell min-h-screen text-slate-50">
       <header className="border-b border-white/8 bg-slate-950/40 backdrop-blur-xl">
-        <nav className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4 sm:px-6">
+        <nav
+          className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4 sm:px-6"
+          aria-label="Dashboard navigation"
+        >
           <div>
-            <Link href="/" className="text-lg font-semibold tracking-tight text-white">
+            <Link
+              href="/"
+              className="text-lg font-semibold tracking-tight text-white"
+              aria-label="ChronoPay home"
+            >
               ChronoPay
             </Link>
             <p className="text-xs uppercase tracking-[0.2em] text-slate-500">

--- a/src/app/components/empty-state-card.tsx
+++ b/src/app/components/empty-state-card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import { EmptyStateIllustration } from "./empty-state-illustration";
 import { StatusChip } from "./ui/status-chip";
 
@@ -24,20 +24,39 @@ export function EmptyStateCard({
   guidance,
   actions,
 }: EmptyStateCardProps) {
+  const cardId = useId();
+  const titleId = `${cardId}-title`;
+  const descriptionId = `${cardId}-description`;
+  const statusId = `${cardId}-status`;
+
   return (
-    <section className="glass-panel rounded-[2rem] p-5 sm:p-6">
+    <section
+      className="glass-panel rounded-[2rem] p-5 sm:p-6"
+      aria-labelledby={titleId}
+      aria-describedby={`${descriptionId} ${statusId}`}
+    >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
           {eyebrow}
         </p>
-        <StatusChip tone={status.tone}>{status.label}</StatusChip>
+        <StatusChip
+          id={statusId}
+          tone={status.tone}
+          aria-label={`${eyebrow} status: ${status.label}`}
+        >
+          {status.label}
+        </StatusChip>
       </div>
       <div className="mt-4">
         <EmptyStateIllustration accentLabel={accentLabel} />
       </div>
       <div className="mt-5 space-y-3">
-        <h2 className="text-xl font-semibold text-white">{title}</h2>
-        <p className="max-w-xl text-sm leading-6 text-slate-300">{description}</p>
+        <h2 id={titleId} className="text-xl font-semibold text-white">
+          {title}
+        </h2>
+        <p id={descriptionId} className="max-w-xl text-sm leading-6 text-slate-300">
+          {description}
+        </p>
         <ul className="space-y-2 text-sm text-slate-300" aria-label={`${title} guidance`}>
           {guidance.map((item) => (
             <li

--- a/src/app/components/ui/button-link.tsx
+++ b/src/app/components/ui/button-link.tsx
@@ -1,10 +1,7 @@
 import Link from "next/link";
-import type { LinkProps } from "next/link";
-import type { ReactNode } from "react";
+import type { ComponentProps } from "react";
 
-type ButtonLinkProps = LinkProps & {
-  children: ReactNode;
-  className?: string;
+type ButtonLinkProps = ComponentProps<typeof Link> & {
   variant?: "primary" | "secondary" | "ghost";
 };
 

--- a/src/app/components/ui/status-chip.tsx
+++ b/src/app/components/ui/status-chip.tsx
@@ -1,7 +1,10 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
 type StatusChipProps = {
   tone?: "info" | "warning" | "success" | "danger" | "neutral";
-  children: React.ReactNode;
-};
+  children: ReactNode;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLSpanElement>, "className">;
 
 const toneClasses = {
   info: "border-cyan-300/25 bg-cyan-300/12 text-cyan-100",
@@ -11,10 +14,16 @@ const toneClasses = {
   neutral: "border-white/10 bg-white/6 text-slate-200",
 };
 
-export function StatusChip({ tone = "neutral", children }: StatusChipProps) {
+export function StatusChip({
+  tone = "neutral",
+  children,
+  className = "",
+  ...props
+}: StatusChipProps) {
   return (
     <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium tracking-[0.14em] uppercase ${toneClasses[tone]}`}
+      {...props}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium tracking-[0.14em] uppercase ${toneClasses[tone]} ${className}`}
     >
       {children}
     </span>

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -20,23 +20,36 @@ export default function DashboardError({
       <section
         role="alert"
         className="glass-panel mx-auto max-w-2xl rounded-[2rem] p-6 sm:p-8"
+        aria-labelledby="dashboard-error-title"
+        aria-describedby="dashboard-error-description dashboard-error-message"
       >
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-rose-300">
           Error state
         </p>
-        <h1 className="mt-4 text-3xl font-semibold tracking-tight text-white">
+        <h1
+          id="dashboard-error-title"
+          className="mt-4 text-3xl font-semibold tracking-tight text-white"
+        >
           We could not load your booking workspace
         </h1>
-        <p className="mt-4 text-sm leading-7 text-slate-300">
+        <p
+          id="dashboard-error-description"
+          className="mt-4 text-sm leading-7 text-slate-300"
+        >
           Nothing has been published or charged. Try again to reload the dashboard, or return home if you want to restart from a safe point.
         </p>
-        <div className="mt-6 rounded-[1.5rem] border border-rose-300/15 bg-rose-300/10 px-4 py-3 text-sm text-rose-100">
+        <div
+          id="dashboard-error-message"
+          className="mt-6 rounded-[1.5rem] border border-rose-300/15 bg-rose-300/10 px-4 py-3 text-sm text-rose-100"
+        >
           {error.message || "Unexpected dashboard error."}
         </div>
         <div className="mt-6 flex flex-wrap gap-3">
           <button
             type="button"
             onClick={reset}
+            aria-label="Retry loading the dashboard"
+            aria-describedby="dashboard-error-message"
             className="inline-flex items-center justify-center rounded-full bg-cyan-300 px-4 py-2.5 text-sm font-medium text-slate-950 hover:bg-cyan-200"
           >
             Try again

--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -3,9 +3,19 @@ import { DashboardShell } from "../components/dashboard-shell";
 export default function DashboardLoading() {
   return (
     <DashboardShell>
-      <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]" aria-busy="true" aria-live="polite">
+      <div
+        className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        aria-label="Loading dashboard overview"
+      >
         {[0, 1].map((item) => (
-          <section key={item} className="glass-panel rounded-[2rem] p-6 sm:p-8">
+          <section
+            key={item}
+            className="glass-panel rounded-[2rem] p-6 sm:p-8"
+            aria-hidden="true"
+          >
             <div className="h-6 w-28 rounded-full bg-white/8" />
             <div className="mt-5 h-10 max-w-xl rounded-2xl bg-white/10" />
             <div className="mt-3 h-5 max-w-2xl rounded-full bg-white/6" />
@@ -19,7 +29,11 @@ export default function DashboardLoading() {
       </div>
       <div className="mt-6 grid gap-4 md:grid-cols-3">
         {[0, 1, 2].map((item) => (
-          <div key={item} className="glass-panel h-40 rounded-[1.5rem] bg-white/4" />
+          <div
+            key={item}
+            className="glass-panel h-40 rounded-[1.5rem] bg-white/4"
+            aria-hidden="true"
+          />
         ))}
       </div>
     </DashboardShell>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,21 +1,6 @@
 import Link from "next/link";
 import DesignChecklist from "@/components/design/DesignChecklist";
 
-import {
-  bookingStages,
-  BookingProgress,
-  metrics,
-  MetricCard,
-  PanelShell,
-  quickActions,
-  QuickActions,
-  slots,
-  SlotList,
-  StateCard,
-  wallet,
-  WalletCard,
-} from "@/components/dashboard";
-
 export default function Dashboard() {
   // Simulated states (for QA requirement)
   const loading = false;
@@ -24,7 +9,11 @@ export default function Dashboard() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-zinc-400">
+      <div
+        className="min-h-screen flex items-center justify-center text-zinc-400"
+        role="status"
+        aria-live="polite"
+      >
         Loading dashboard...
       </div>
     );
@@ -32,7 +21,10 @@ export default function Dashboard() {
 
   if (error) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-red-500">
+      <div
+        className="min-h-screen flex items-center justify-center text-red-500"
+        role="alert"
+      >
         Something went wrong.
       </div>
     );
@@ -40,7 +32,10 @@ export default function Dashboard() {
 
   if (!hasData) {
     return (
-      <div className="min-h-screen flex items-center justify-center text-zinc-400">
+      <div
+        className="min-h-screen flex items-center justify-center text-zinc-400"
+        role="status"
+      >
         No data available.
       </div>
     );
@@ -51,8 +46,11 @@ export default function Dashboard() {
       
       {/* Header */}
       <header className="border-b border-zinc-800 px-6 py-4">
-        <nav className="flex items-center justify-between max-w-5xl mx-auto">
-          <Link href="/" className="text-lg font-semibold">
+        <nav
+          className="flex items-center justify-between max-w-5xl mx-auto"
+          aria-label="Dashboard navigation"
+        >
+          <Link href="/" className="text-lg font-semibold" aria-label="ChronoPay home">
             ChronoPay
           </Link>
           <div className="flex gap-4 text-sm text-zinc-400">
@@ -64,34 +62,62 @@ export default function Dashboard() {
       </header>
 
       {/* Main */}
-      <main className="max-w-5xl mx-auto px-6 py-16 space-y-10">
+      <main
+        className="max-w-5xl mx-auto px-6 py-16 space-y-10"
+        aria-labelledby="dashboard-title"
+        aria-describedby="dashboard-description"
+      >
         
         {/* Title */}
         <div>
-          <h1 className="text-2xl font-bold">Dashboard</h1>
-          <p className="mt-2 text-zinc-400">
+          <h1 id="dashboard-title" className="text-2xl font-bold">
+            Dashboard
+          </h1>
+          <p id="dashboard-description" className="mt-2 text-zinc-400">
             Connect your Stellar wallet to mint and trade time tokens.
           </p>
         </div>
 
         {/* Wallet Card */}
-        <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
-          <h2 className="text-lg font-semibold mb-2">Wallet Status</h2>
-          <p className="text-sm text-zinc-400">
+        <section
+          className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6"
+          aria-labelledby="wallet-status-title"
+          aria-describedby="wallet-status-value"
+        >
+          <h2 id="wallet-status-title" className="text-lg font-semibold mb-2">
+            Wallet Status
+          </h2>
+          <p id="wallet-status-value" className="text-sm text-zinc-400" aria-live="polite">
             Not connected
           </p>
-          <button className="mt-4 px-4 py-2 text-sm rounded-lg bg-white text-black hover:bg-zinc-200 transition">
+          <button
+            type="button"
+            className="mt-4 px-4 py-2 text-sm rounded-lg bg-white text-black hover:bg-zinc-200 transition"
+            aria-label="Connect Stellar wallet to ChronoPay dashboard"
+            aria-describedby="wallet-status-value"
+          >
             Connect Wallet
           </button>
-        </div>
+        </section>
 
         {/* Time Slots Section */}
-        <div className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
-          <h2 className="text-lg font-semibold mb-4">Available Time Slots</h2>
-          <p className="text-sm text-zinc-500">
+        <section
+          className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-6"
+          aria-labelledby="available-slots-title"
+          aria-describedby="available-slots-status"
+        >
+          <h2 id="available-slots-title" className="text-lg font-semibold mb-4">
+            Available Time Slots
+          </h2>
+          <p
+            id="available-slots-status"
+            className="text-sm text-zinc-500"
+            role="status"
+            aria-live="polite"
+          >
             No time slots listed yet.
           </p>
-        </div>
+        </section>
 
         {/* Design QA Checklist (IMPORTANT FOR ISSUE) */}
         <DesignChecklist />

--- a/src/components/dashboard/booking-progress.tsx
+++ b/src/components/dashboard/booking-progress.tsx
@@ -1,27 +1,51 @@
 import type { BookingStage } from "./types";
 
+function toElementId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
 export function BookingProgress({ stages }: { stages: BookingStage[] }) {
   const maxValue = Math.max(...stages.map((stage) => stage.value), 1);
 
   return (
-    <div className="space-y-5">
-      {stages.map((stage) => (
-        <div key={stage.label}>
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <p className="text-sm font-medium text-white">{stage.label}</p>
-            <p className="text-sm text-slate-300">{stage.value} bookings</p>
-          </div>
+    <div
+      className="space-y-5"
+      role="list"
+      aria-label="Booking progress by stage"
+      aria-live="polite"
+    >
+      {stages.map((stage, index) => {
+        const stageId = `booking-stage-${toElementId(stage.label)}-${index + 1}`;
+        const labelId = `${stageId}-label`;
+        const valueId = `${stageId}-value`;
+
+        return (
           <div
-            className="h-2.5 rounded-full bg-white/10"
-            aria-hidden="true"
+            key={`${stage.label}-${index}`}
+            role="listitem"
+            aria-labelledby={labelId}
+            aria-describedby={valueId}
           >
-            <div
-              className="h-2.5 rounded-full bg-[linear-gradient(90deg,#67e8f9,#22c55e)]"
-              style={{ width: `${(stage.value / maxValue) * 100}%` }}
-            />
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <p id={labelId} className="text-sm font-medium text-white">
+                {stage.label}
+              </p>
+              <p id={valueId} className="text-sm text-slate-300" aria-atomic="true">
+                {stage.value} bookings
+              </p>
+            </div>
+            <div className="h-2.5 rounded-full bg-white/10" aria-hidden="true">
+              <div
+                className="h-2.5 rounded-full bg-[linear-gradient(90deg,#67e8f9,#22c55e)]"
+                style={{ width: `${(stage.value / maxValue) * 100}%` }}
+              />
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/dashboard/metric-card.tsx
+++ b/src/components/dashboard/metric-card.tsx
@@ -1,19 +1,59 @@
 import { StatusChip } from "./status-chip";
-import type { Metric } from "./types";
+import type { Metric, Tone } from "./types";
+
+const toneLabels: Record<Tone, string> = {
+  neutral: "Stable",
+  positive: "On track",
+  warning: "Needs review",
+  critical: "Needs attention",
+};
+
+function toElementId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
 
 export function MetricCard({ metric }: { metric: Metric }) {
+  const metricId = `metric-${toElementId(metric.label)}`;
+  const labelId = `${metricId}-label`;
+  const valueId = `${metricId}-value`;
+  const detailId = `${metricId}-detail`;
+  const statusId = `${metricId}-status`;
+  const statusLabel = toneLabels[metric.tone];
+
   return (
-    <article className="rounded-[24px] border border-white/10 bg-white/5 p-5">
+    <article
+      className="rounded-[24px] border border-white/10 bg-white/5 p-5"
+      aria-labelledby={labelId}
+      aria-describedby={`${valueId} ${detailId} ${statusId}`}
+    >
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm text-slate-300">{metric.label}</p>
-          <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          <p id={labelId} className="text-sm text-slate-300">
+            {metric.label}
+          </p>
+          <p
+            id={valueId}
+            className="mt-3 text-3xl font-semibold tracking-tight text-white"
+            aria-live="polite"
+            aria-atomic="true"
+          >
             {metric.value}
           </p>
         </div>
-        <StatusChip tone={metric.tone}>{metric.tone}</StatusChip>
+        <StatusChip
+          id={statusId}
+          tone={metric.tone}
+          aria-label={`${metric.label} status: ${statusLabel}`}
+        >
+          {statusLabel}
+        </StatusChip>
       </div>
-      <p className="mt-4 text-sm leading-6 text-slate-400">{metric.detail}</p>
+      <p id={detailId} className="mt-4 text-sm leading-6 text-slate-400">
+        {metric.detail}
+      </p>
     </article>
   );
 }

--- a/src/components/dashboard/panel-shell.tsx
+++ b/src/components/dashboard/panel-shell.tsx
@@ -1,3 +1,5 @@
+import { useId, type ReactNode } from "react";
+
 export function PanelShell({
   title,
   eyebrow,
@@ -8,11 +10,19 @@ export function PanelShell({
   title: string;
   eyebrow?: string;
   description?: string;
-  action?: React.ReactNode;
-  children: React.ReactNode;
+  action?: ReactNode;
+  children: ReactNode;
 }) {
+  const shellId = useId();
+  const titleId = `${shellId}-title`;
+  const descriptionId = description ? `${shellId}-description` : undefined;
+
   return (
-    <section className="rounded-[28px] border border-white/10 bg-slate-950/70 p-5 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.95)] backdrop-blur xl:p-6">
+    <section
+      className="rounded-[28px] border border-white/10 bg-slate-950/70 p-5 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.95)] backdrop-blur xl:p-6"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+    >
       <div className="flex flex-col gap-4 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-2">
           {eyebrow ? (
@@ -21,9 +31,14 @@ export function PanelShell({
             </p>
           ) : null}
           <div>
-            <h2 className="text-xl font-semibold text-white">{title}</h2>
+            <h2 id={titleId} className="text-xl font-semibold text-white">
+              {title}
+            </h2>
             {description ? (
-              <p className="mt-1 max-w-2xl text-sm leading-6 text-slate-300">
+              <p
+                id={descriptionId}
+                className="mt-1 max-w-2xl text-sm leading-6 text-slate-300"
+              >
                 {description}
               </p>
             ) : null}

--- a/src/components/dashboard/quick-actions.tsx
+++ b/src/components/dashboard/quick-actions.tsx
@@ -1,31 +1,78 @@
 import Link from "next/link";
 
 import { StatusChip } from "./status-chip";
-import type { QuickAction } from "./types";
+import type { QuickAction, Tone } from "./types";
+
+const toneLabels: Record<Tone, string> = {
+  neutral: "Available",
+  positive: "Ready",
+  warning: "Needs review",
+  critical: "Needs attention",
+};
+
+function toElementId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
 
 export function QuickActions({ actions }: { actions: QuickAction[] }) {
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      {actions.map((action) => (
-        <Link
-          key={action.title}
-          href={action.href}
-          className="group rounded-[24px] border border-white/10 bg-slate-900/80 p-5 transition hover:-translate-y-0.5 hover:border-cyan-300/40 hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
-        >
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <h3 className="text-lg font-semibold text-white">{action.title}</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-300">
-                {action.description}
+    <div
+      className="grid gap-4 md:grid-cols-3"
+      role="list"
+      aria-label="Quick actions"
+    >
+      {actions.map((action, index) => {
+        const actionId = `quick-action-${toElementId(action.title)}-${index + 1}`;
+        const titleId = `${actionId}-title`;
+        const positionId = `${actionId}-position`;
+        const descriptionId = `${actionId}-description`;
+        const statusId = `${actionId}-status`;
+        const statusLabel = toneLabels[action.tone];
+
+        return (
+          <div key={`${action.title}-${index}`} role="listitem">
+            <Link
+              href={action.href}
+              className="group block h-full rounded-[24px] border border-white/10 bg-slate-900/80 p-5 transition hover:-translate-y-0.5 hover:border-cyan-300/40 hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              aria-labelledby={`${titleId} ${positionId}`}
+              aria-describedby={`${descriptionId} ${statusId}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 id={titleId} className="text-lg font-semibold text-white">
+                    {action.title}
+                  </h3>
+                  <span id={positionId} className="sr-only">
+                    workflow {index + 1} of {actions.length}
+                  </span>
+                  <p
+                    id={descriptionId}
+                    className="mt-2 text-sm leading-6 text-slate-300"
+                  >
+                    {action.description}
+                  </p>
+                </div>
+                <StatusChip
+                  id={statusId}
+                  tone={action.tone}
+                  aria-label={`${action.title} workflow status: ${statusLabel}`}
+                >
+                  {statusLabel}
+                </StatusChip>
+              </div>
+              <p
+                className="mt-5 text-sm font-medium text-cyan-200 transition group-hover:text-cyan-100"
+                aria-hidden="true"
+              >
+                Open workflow
               </p>
-            </div>
-            <StatusChip tone={action.tone}>{action.tone}</StatusChip>
+            </Link>
           </div>
-          <p className="mt-5 text-sm font-medium text-cyan-200 transition group-hover:text-cyan-100">
-            Open workflow
-          </p>
-        </Link>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/dashboard/slot-list.tsx
+++ b/src/components/dashboard/slot-list.tsx
@@ -13,28 +13,61 @@ function mapTone(status: Slot["status"]) {
   return "critical";
 }
 
+function toElementId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
 export function SlotList({ slots }: { slots: Slot[] }) {
   return (
     <ul className="space-y-3" aria-label="Available time slots">
-      {slots.map((slot) => (
-        <li
-          key={slot.id}
-          className="rounded-[22px] border border-white/10 bg-white/5 p-4"
-        >
-          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h3 className="text-base font-semibold text-white">{slot.title}</h3>
-              <p className="mt-1 text-sm text-slate-300">{slot.window}</p>
+      {slots.map((slot, index) => {
+        const slotId = `slot-${toElementId(slot.id)}-${index + 1}`;
+        const titleId = `${slotId}-title`;
+        const windowId = `${slotId}-window`;
+        const statusId = `${slotId}-status`;
+        const demandId = `${slotId}-demand`;
+        const rateId = `${slotId}-rate`;
+        const slotPosition = `${index + 1} of ${slots.length}`;
+
+        return (
+          <li
+            key={`${slot.id}-${index}`}
+            className="rounded-[22px] border border-white/10 bg-white/5 p-4"
+            aria-label={`${slot.title} time slot ${slotPosition}`}
+            aria-describedby={`${windowId} ${statusId} ${demandId} ${rateId}`}
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 id={titleId} className="text-base font-semibold text-white">
+                  {slot.title}
+                </h3>
+                <p id={windowId} className="mt-1 text-sm text-slate-300">
+                  {slot.window}
+                </p>
+              </div>
+              <StatusChip
+                id={statusId}
+                tone={mapTone(slot.status)}
+                aria-label={`Availability for ${slot.title}: ${slot.status}`}
+                aria-live="polite"
+                aria-atomic="true"
+              >
+                {slot.status}
+              </StatusChip>
             </div>
-            <StatusChip tone={mapTone(slot.status)}>{slot.status}</StatusChip>
-          </div>
-          <div className="mt-4 flex flex-wrap gap-3 text-sm text-slate-400">
-            <span>{slot.demand}</span>
-            <span className="text-slate-600">•</span>
-            <span>{slot.rate}</span>
-          </div>
-        </li>
-      ))}
+            <div className="mt-4 flex flex-wrap gap-3 text-sm text-slate-400">
+              <span id={demandId}>{slot.demand}</span>
+              <span className="text-slate-600" aria-hidden="true">
+                •
+              </span>
+              <span id={rateId}>{slot.rate}</span>
+            </div>
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/dashboard/state-card.tsx
+++ b/src/components/dashboard/state-card.tsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import type { Tone } from "./types";
 
 type StateType = "loading" | "empty" | "error";
@@ -22,10 +24,20 @@ const stateMessage: Record<StateType, string> = {
 
 export function StateCard({ state }: { state: StateType }) {
   const tone = stateTone[state];
+  const stateId = useId();
+  const titleId = `${stateId}-title`;
+  const messageId = `${stateId}-message`;
+  const statusId = `${stateId}-status`;
+  const buttonLabel =
+    state === "error"
+      ? "Retry wallet and booking sync"
+      : `Review ${state} dashboard state details`;
 
   return (
     <article
       className="rounded-[24px] border border-white/10 bg-white/5 p-5"
+      aria-labelledby={titleId}
+      aria-describedby={`${messageId} ${statusId}`}
       aria-live={state === "loading" ? "polite" : undefined}
     >
       <div className="flex items-center justify-between gap-4">
@@ -33,7 +45,7 @@ export function StateCard({ state }: { state: StateType }) {
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
             {stateTitle[state]}
           </p>
-          <p className="mt-2 text-lg font-semibold text-white">
+          <p id={titleId} className="mt-2 text-lg font-semibold text-white">
             {state === "loading"
               ? "Syncing dashboard signals"
               : state === "empty"
@@ -42,6 +54,8 @@ export function StateCard({ state }: { state: StateType }) {
           </p>
         </div>
         <span
+          id={statusId}
+          aria-label={`Dashboard state: ${state}`}
           className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${
             tone === "neutral"
               ? "bg-sky-400/10 text-sky-100"
@@ -55,17 +69,26 @@ export function StateCard({ state }: { state: StateType }) {
       </div>
       <div className="mt-5">
         {state === "loading" ? (
-          <div className="space-y-3" aria-hidden="true">
-            <div className="h-3 w-3/4 animate-pulse rounded-full bg-white/10" />
-            <div className="h-3 w-1/2 animate-pulse rounded-full bg-white/10" />
-            <div className="h-10 w-full animate-pulse rounded-2xl bg-white/10" />
-          </div>
+          <>
+            <p id={messageId} className="sr-only">
+              {stateMessage[state]}
+            </p>
+            <div className="space-y-3" aria-hidden="true">
+              <div className="h-3 w-3/4 animate-pulse rounded-full bg-white/10" />
+              <div className="h-3 w-1/2 animate-pulse rounded-full bg-white/10" />
+              <div className="h-10 w-full animate-pulse rounded-2xl bg-white/10" />
+            </div>
+          </>
         ) : (
-          <p className="text-sm leading-6 text-slate-300">{stateMessage[state]}</p>
+          <p id={messageId} className="text-sm leading-6 text-slate-300">
+            {stateMessage[state]}
+          </p>
         )}
       </div>
       <button
         type="button"
+        aria-label={buttonLabel}
+        aria-describedby={messageId}
         className="mt-5 inline-flex rounded-full border border-white/15 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
       >
         {state === "error" ? "Retry sync" : "Review details"}

--- a/src/components/dashboard/status-chip.tsx
+++ b/src/components/dashboard/status-chip.tsx
@@ -1,3 +1,5 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
 import type { Tone } from "./types";
 
 const toneClasses: Record<Tone, string> = {
@@ -10,13 +12,17 @@ const toneClasses: Record<Tone, string> = {
 export function StatusChip({
   tone,
   children,
+  className = "",
+  ...props
 }: {
   tone: Tone;
-  children: React.ReactNode;
-}) {
+  children: ReactNode;
+  className?: string;
+} & Omit<HTMLAttributes<HTMLSpanElement>, "className">) {
   return (
     <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${toneClasses[tone]}`}
+      {...props}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${toneClasses[tone]} ${className}`}
     >
       {children}
     </span>

--- a/src/components/dashboard/wallet-card.tsx
+++ b/src/components/dashboard/wallet-card.tsx
@@ -2,16 +2,38 @@ import { StatusChip } from "./status-chip";
 import type { WalletSnapshot } from "./types";
 
 export function WalletCard({ wallet }: { wallet: WalletSnapshot }) {
+  const titleId = "primary-wallet-title";
+  const balanceId = "primary-wallet-balance";
+  const securityId = "primary-wallet-security";
+  const statusId = "primary-wallet-sync-status";
+
   return (
-    <article className="rounded-[24px] border border-cyan-400/20 bg-[linear-gradient(160deg,rgba(14,116,144,0.18),rgba(15,23,42,0.92))] p-5">
+    <article
+      className="rounded-[24px] border border-cyan-400/20 bg-[linear-gradient(160deg,rgba(14,116,144,0.18),rgba(15,23,42,0.92))] p-5"
+      aria-labelledby={titleId}
+      aria-describedby={`${balanceId} ${securityId} ${statusId}`}
+    >
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm text-cyan-100/80">Primary wallet</p>
-          <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+          <p id={titleId} className="text-sm text-cyan-100/80">
+            Primary wallet
+          </p>
+          <p
+            id={balanceId}
+            className="mt-3 text-3xl font-semibold tracking-tight text-white"
+            aria-live="polite"
+            aria-atomic="true"
+          >
             {wallet.balance}
           </p>
         </div>
-        <StatusChip tone="neutral">secured</StatusChip>
+        <StatusChip
+          id={securityId}
+          tone="neutral"
+          aria-label="Primary wallet security status: secured"
+        >
+          secured
+        </StatusChip>
       </div>
       <dl className="mt-6 space-y-4">
         <div className="flex items-center justify-between gap-4 text-sm">
@@ -23,7 +45,14 @@ export function WalletCard({ wallet }: { wallet: WalletSnapshot }) {
           <dd className="font-medium text-white">{wallet.nextPayout}</dd>
         </div>
       </dl>
-      <p className="mt-6 text-sm text-cyan-100/75">{wallet.status}</p>
+      <p
+        id={statusId}
+        className="mt-6 text-sm text-cyan-100/75"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {wallet.status}
+      </p>
     </article>
   );
 }

--- a/src/components/design/DesignChecklist.tsx
+++ b/src/components/design/DesignChecklist.tsx
@@ -9,15 +9,21 @@ export default function DesignChecklist() {
   ];
 
   return (
-    <div className="p-5 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-md shadow-lg">
-      <h2 className="text-lg font-semibold mb-4">
-        🎯 Design QA Checklist
+    <div
+      className="p-5 rounded-2xl border border-white/10 bg-white/5 backdrop-blur-md shadow-lg"
+      aria-labelledby="design-qa-checklist-title"
+    >
+      <h2 id="design-qa-checklist-title" className="text-lg font-semibold mb-4">
+        <span aria-hidden="true">🎯 </span>
+        Design QA Checklist
       </h2>
 
       <ul className="space-y-2 text-sm">
         {items.map((item, i) => (
           <li key={i} className="flex items-center gap-2">
-            <span className="text-green-400">✔</span>
+            <span className="text-green-400" aria-hidden="true">
+              ✔
+            </span>
             {item}
           </li>
         ))}


### PR DESCRIPTION
Closes #65

---

Updated dashboard/page states, reusable dashboard cards/lists/chips, shared UI chips, and README guidance. Key UX changes: unique workflow/link labels, contextual status chip announcements, slot item descriptions, polite live updates for dynamic values, and hidden decorative skeleton/icons.

Validation:

npm run lint: passed
npm run build: passed
npm audit --omit=dev: found pre-existing production advisories in next@16.1.6 / bundled postcss; npm’s suggested fix upgrades Next outside the exact pinned version, so I left that out of this UI-only commit.
Security scope: no wallet logic, API calls, auth, transactions, or persisted data changed.