### PR TITLE
design: add reusable card pattern and migrate inline styles

### DIFF
--- a/src/app/components/empty-state-card.tsx
+++ b/src/app/components/empty-state-card.tsx
@@ -1,6 +1,7 @@
 import { useId, type ReactNode } from "react";
 import { EmptyStateIllustration } from "./empty-state-illustration";
 import { StatusChip } from "./ui/status-chip";
+import { Card, CardHeader, CardBody, CardFooter } from "@/components/dashboard";
 
 type EmptyStateCardProps = {
   eyebrow: string;
@@ -30,12 +31,13 @@ export function EmptyStateCard({
   const statusId = `${cardId}-status`;
 
   return (
-    <section
-      className="glass-panel rounded-[2rem] p-5 sm:p-6"
+    <Card
+      as="section"
+      variant="glass"
       aria-labelledby={titleId}
       aria-describedby={`${descriptionId} ${statusId}`}
     >
-      <div className="flex flex-wrap items-center justify-between gap-3">
+      <CardHeader className="flex-wrap items-center justify-between gap-3">
         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
           {eyebrow}
         </p>
@@ -46,29 +48,33 @@ export function EmptyStateCard({
         >
           {status.label}
         </StatusChip>
-      </div>
-      <div className="mt-4">
+      </CardHeader>
+      <CardBody className="mt-4">
         <EmptyStateIllustration accentLabel={accentLabel} />
-      </div>
-      <div className="mt-5 space-y-3">
-        <h2 id={titleId} className="text-xl font-semibold text-white">
-          {title}
-        </h2>
-        <p id={descriptionId} className="max-w-xl text-sm leading-6 text-slate-300">
-          {description}
-        </p>
-        <ul className="space-y-2 text-sm text-slate-300" aria-label={`${title} guidance`}>
-          {guidance.map((item) => (
-            <li
-              key={item}
-              className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3"
-            >
-              {item}
-            </li>
-          ))}
-        </ul>
-      </div>
-      {actions ? <div className="mt-5 flex flex-wrap gap-3">{actions}</div> : null}
-    </section>
+        <div className="mt-5 space-y-3">
+          <h2 id={titleId} className="text-xl font-semibold text-white">
+            {title}
+          </h2>
+          <p id={descriptionId} className="max-w-xl text-sm leading-6 text-slate-300">
+            {description}
+          </p>
+          <ul className="space-y-2 text-sm text-slate-300" aria-label={`${title} guidance`}>
+            {guidance.map((item) => (
+              <li
+                key={item}
+                className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </CardBody>
+      {actions ? (
+        <CardFooter className="mt-5 flex flex-wrap gap-3">
+          {actions}
+        </CardFooter>
+      ) : null}
+    </Card>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,12 @@
   --helper-text-color: rgb(203 213 225);          /* slate-300, primary helper tone */
   --helper-text-color-muted: rgb(148 163 184);    /* slate-400, metadata / empty states */
   --helper-text-color-emphasis: rgb(207 250 254 / 0.8); /* cyan-100/80, accent panels */
+
+  /* Reusable Card design tokens */
+  --radius-md: 24px;
+  --radius-lg: 28px;
+  --radius-xl: 32px;
+  --border: 1px solid var(--border-subtle);
 }
 
 @theme inline {
@@ -71,4 +77,107 @@ body {
 
 .helper-text--emphasis {
   color: var(--helper-text-color-emphasis);
+}
+
+/*
+ * Reusable Card Design Pattern
+ * Source of consistency for borders, backgrounds, spacing, and hover feedback.
+ */
+.card {
+  border-radius: var(--radius-md);
+  border: var(--border);
+  background-color: var(--surface);
+  padding: 1.25rem; /* p-5 (20px) */
+  display: flex;
+  flex-direction: column;
+}
+
+.card-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card-body {
+  flex: 1 1 auto;
+}
+
+.card-footer {
+  margin-top: 1.25rem; /* mt-5 */
+}
+
+/* Panel Shell Variant */
+.card--panel {
+  border-radius: var(--radius-lg);
+  background-color: rgba(15, 23, 42, 0.7); /* slate-950/70 */
+  backdrop-filter: blur(8px);
+  padding: 1rem; /* p-4 */
+  box-shadow: 0 24px 80px -40px rgba(15, 23, 42, 0.95);
+}
+
+@media (min-width: 640px) {
+  .card--panel {
+    padding: 1.25rem; /* sm:p-5 */
+  }
+}
+
+@media (min-width: 1280px) {
+  .card--panel {
+    padding: 1.5rem; /* xl:p-6 */
+  }
+}
+
+/* Glass Card Variant (used by empty states) */
+.card--glass {
+  border-radius: var(--radius-xl); /* 2rem */
+  background: rgba(11, 23, 40, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+  padding: 1.25rem; /* p-5 */
+}
+
+@media (min-width: 640px) {
+  .card--glass {
+    padding: 1.5rem; /* sm:p-6 */
+  }
+}
+
+/* Accent Card Variant (used by Wallet Card) */
+.card--accent {
+  border-color: rgba(34, 211, 238, 0.2); /* border-cyan-400/20 */
+  background: linear-gradient(160deg, rgba(14, 116, 144, 0.18), rgba(15, 23, 42, 0.92));
+}
+
+.card--accent:hover {
+  border-color: rgba(34, 211, 238, 0.4); /* hover:border-cyan-400/40 */
+}
+
+/* Interactive Card Modifier (hover, active, transition effects) */
+.card--interactive {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card--interactive {
+    transition-duration: 200ms;
+  }
+  .card--interactive:hover {
+    transform: translateY(-2px);
+  }
+  .card--interactive:active {
+    transform: translateY(0);
+  }
+}
+
+.card--interactive:hover {
+  border-color: rgba(103, 232, 249, 0.4); /* hover:border-cyan-300/40 */
+  background-color: rgb(15, 23, 42); /* hover:bg-slate-900 */
+}
+
+.card--interactive:active {
+  border-color: rgba(103, 232, 249, 0.6); /* active:border-cyan-300/60 */
+  background-color: rgb(30, 41, 59); /* active:bg-slate-800 */
 }

--- a/src/components/dashboard/card.tsx
+++ b/src/components/dashboard/card.tsx
@@ -1,0 +1,85 @@
+import { ReactNode, ElementType } from "react";
+import clsx from "clsx";
+
+export interface CardProps {
+  as?: ElementType;
+  children: ReactNode;
+  className?: string;
+  variant?: "default" | "panel" | "glass" | "accent";
+  interactive?: boolean;
+  [key: string]: any;
+}
+
+export function Card({
+  as: Component = "article",
+  children,
+  className,
+  variant = "default",
+  interactive = false,
+  ...props
+}: CardProps) {
+  const cardClassName = clsx(
+    "card",
+    {
+      "card--panel": variant === "panel",
+      "card--glass": variant === "glass",
+      "card--accent": variant === "accent",
+      "card--interactive": interactive,
+    },
+    className
+  );
+
+  return (
+    <Component className={cardClassName} {...props}>
+      {children}
+    </Component>
+  );
+}
+
+export function CardHeader({
+  children,
+  className,
+  ...props
+}: {
+  children: ReactNode;
+  className?: string;
+  [key: string]: any;
+}) {
+  return (
+    <div className={clsx("card-header", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardBody({
+  children,
+  className,
+  ...props
+}: {
+  children: ReactNode;
+  className?: string;
+  [key: string]: any;
+}) {
+  return (
+    <div className={clsx("card-body", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function CardFooter({
+  children,
+  className,
+  ...props
+}: {
+  children: ReactNode;
+  className?: string;
+  [key: string]: any;
+}) {
+  return (
+    <div className={clsx("card-footer", className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -7,3 +7,5 @@ export * from "./slot-list";
 export * from "./state-card";
 export * from "./status-chip";
 export * from "./wallet-card";
+export * from "./card";
+

--- a/src/components/dashboard/metric-card.tsx
+++ b/src/components/dashboard/metric-card.tsx
@@ -1,4 +1,5 @@
 import { StatusChip } from "./status-chip";
+import { Card, CardHeader, CardBody } from "./card";
 import type { Metric, Tone } from "./types";
 
 const toneLabels: Record<Tone, string> = {
@@ -24,12 +25,11 @@ export function MetricCard({ metric }: { metric: Metric }) {
   const statusLabel = toneLabels[metric.tone];
 
   return (
-    <article
-      className="rounded-[24px] border border-white/10 bg-white/5 p-5"
+    <Card
       aria-labelledby={labelId}
       aria-describedby={`${valueId} ${detailId} ${statusId}`}
     >
-      <div className="flex items-start justify-between gap-4">
+      <CardHeader>
         <div>
           <p id={labelId} className="text-sm text-slate-300">
             {metric.label}
@@ -50,10 +50,13 @@ export function MetricCard({ metric }: { metric: Metric }) {
         >
           {statusLabel}
         </StatusChip>
-      </div>
-      <p id={detailId} className="mt-4 text-sm leading-6 text-slate-400">
-        {metric.detail}
-      </p>
-    </article>
+      </CardHeader>
+      <CardBody className="mt-4">
+        <p id={detailId} className="text-sm leading-6 text-slate-400">
+          {metric.detail}
+        </p>
+      </CardBody>
+    </Card>
   );
 }
+

--- a/src/components/dashboard/panel-shell.tsx
+++ b/src/components/dashboard/panel-shell.tsx
@@ -1,4 +1,5 @@
 import { useId, type ReactNode } from "react";
+import { Card, CardHeader, CardBody } from "./card";
 
 export function PanelShell({
   title,
@@ -18,8 +19,13 @@ export function PanelShell({
   const descriptionId = description ? `${shellId}-description` : undefined;
 
   return (
-    <section className="rounded-[28px] border border-white/10 bg-slate-950/70 p-4 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.95)] backdrop-blur sm:p-5 xl:p-6">
-      <div className="flex flex-col gap-4 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+    <Card
+      as="section"
+      variant="panel"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+    >
+      <CardHeader className="flex-col gap-4 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-2">
           {eyebrow ? (
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200/70">
@@ -41,8 +47,8 @@ export function PanelShell({
           </div>
         </div>
         {action}
-      </div>
-      <div className="pt-5">{children}</div>
-    </section>
+      </CardHeader>
+      <CardBody className="pt-5">{children}</CardBody>
+    </Card>
   );
 }

--- a/src/components/dashboard/quick-actions.tsx
+++ b/src/components/dashboard/quick-actions.tsx
@@ -1,5 +1,6 @@
 import { ButtonLink } from "@/app/components/ui/button-link";
 import { StatusChip } from "./status-chip";
+import { Card, CardHeader, CardFooter } from "./card";
 import type { QuickAction, Tone } from "./types";
 
 const toneLabels: Record<Tone, string> = {
@@ -13,11 +14,13 @@ export function QuickActions({ actions }: { actions: QuickAction[] }) {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
       {actions.map((action) => (
-        <div
+        <Card
+          as="div"
           key={action.title}
-          className="group rounded-[24px] border border-white/10 bg-slate-900/80 p-5 motion-safe:transition hover:border-cyan-300/40 hover:bg-slate-900 flex flex-col justify-between"
+          interactive
+          className="group justify-between"
         >
-          <div className="flex items-start justify-between gap-3">
+          <CardHeader>
             <div>
               <h3 className="text-lg font-semibold text-white">{action.title}</h3>
               <p className="helper-text mt-2">
@@ -25,13 +28,13 @@ export function QuickActions({ actions }: { actions: QuickAction[] }) {
               </p>
             </div>
             <StatusChip tone={action.tone}>{toneLabels[action.tone]}</StatusChip>
-          </div>
-          <div className="mt-6 flex justify-end">
+          </CardHeader>
+          <CardFooter className="mt-6 flex justify-end">
             <ButtonLink href={action.href} variant="secondary" size="md">
               View {action.title}
             </ButtonLink>
-          </div>
-        </div>
+          </CardFooter>
+        </Card>
       ))}
     </div>
   );

--- a/src/components/dashboard/state-card.tsx
+++ b/src/components/dashboard/state-card.tsx
@@ -1,5 +1,5 @@
 import { useId } from "react";
-
+import { Card, CardHeader, CardBody, CardFooter } from "./card";
 import type { Tone } from "./types";
 
 type StateType = "loading" | "empty" | "error";
@@ -34,13 +34,12 @@ export function StateCard({ state }: { state: StateType }) {
       : `Review ${state} dashboard state details`;
 
   return (
-    <article
-      className="rounded-[24px] border border-white/10 bg-white/5 p-5"
+    <Card
       aria-labelledby={titleId}
       aria-describedby={`${messageId} ${statusId}`}
       aria-live={state === "loading" ? "polite" : undefined}
     >
-      <div className="flex items-center justify-between gap-4">
+      <CardHeader>
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
             {stateTitle[state]}
@@ -66,8 +65,8 @@ export function StateCard({ state }: { state: StateType }) {
         >
           {state}
         </span>
-      </div>
-      <div className="mt-5">
+      </CardHeader>
+      <CardBody className="mt-5">
         {state === "loading" ? (
           <>
             <p id={messageId} className="sr-only">
@@ -84,15 +83,17 @@ export function StateCard({ state }: { state: StateType }) {
             {stateMessage[state]}
           </p>
         )}
-      </div>
-      <button
-        type="button"
-        aria-label={buttonLabel}
-        aria-describedby={messageId}
-        className="mt-5 inline-flex items-center justify-center rounded-full font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 px-4 py-2.5 text-sm border border-white/12 bg-white/6 text-slate-100 hover:border-cyan-200/30 hover:bg-white/10"
-      >
-        {state === "error" ? "Retry sync" : "Review details"}
-      </button>
-    </article>
+      </CardBody>
+      <CardFooter className="mt-5">
+        <button
+          type="button"
+          aria-label={buttonLabel}
+          aria-describedby={messageId}
+          className="inline-flex items-center justify-center rounded-full font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 px-4 py-2.5 text-sm border border-white/12 bg-white/6 text-slate-100 hover:border-cyan-200/30 hover:bg-white/10"
+        >
+          {state === "error" ? "Retry sync" : "Review details"}
+        </button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/src/components/dashboard/wallet-card.tsx
+++ b/src/components/dashboard/wallet-card.tsx
@@ -1,6 +1,7 @@
 import { useId } from "react";
 import { StatusChip } from "./status-chip";
 import { Tooltip } from "@/app/components/ui/tooltip";
+import { Card, CardHeader, CardBody, CardFooter } from "./card";
 import type { WalletSnapshot } from "./types";
 
 const statusTone = {
@@ -23,12 +24,12 @@ export function WalletCard({ wallet }: { wallet: WalletSnapshot }) {
   const statusId = useId();
 
   return (
-    <article
-      className="rounded-[24px] border border-cyan-400/20 bg-[linear-gradient(160deg,rgba(14,116,144,0.18),rgba(15,23,42,0.92))] p-5 motion-safe:transition hover:border-cyan-400/40"
+    <Card
+      variant="accent"
       aria-labelledby={titleId}
       aria-describedby={`${balanceId} ${securityId} ${statusId}`}
     >
-      <div className="flex items-start justify-between gap-4">
+      <CardHeader>
         <div className="min-w-0">
           <p id={titleId} className="text-sm text-cyan-100/80">Primary wallet</p>
           <p id={balanceId} className="mt-3 truncate text-2xl font-semibold tracking-tight text-white sm:text-3xl">
@@ -43,37 +44,41 @@ export function WalletCard({ wallet }: { wallet: WalletSnapshot }) {
             ? "Connection issue"
             : "Disconnected"}
         </StatusChip>
-      </div>
-      <dl className="mt-6 space-y-4">
-        <div className="flex items-center justify-between gap-4 text-sm">
-          <dt id={securityId} className="text-slate-300 flex items-center gap-2">
-            Pending escrow
-            <Tooltip content="Time tokens held in escrow for active bookings. Released upon completion or cancellation." />
-          </dt>
-          <dd className="font-medium text-white">{wallet.pending}</dd>
-        </div>
-        <div className="flex items-center justify-between gap-4 text-sm">
-          <dt className="text-slate-300 flex items-center gap-2">
-            Next payout
-            <Tooltip content="Scheduled release of earnings from completed time token transactions." />
-          </dt>
-          <dd className="font-medium text-white">{wallet.nextPayout}</dd>
-        </div>
-      </dl>
-      <p
-        id={statusId}
-        className="mt-6 text-sm text-cyan-100/75"
-        aria-live="polite"
-        aria-atomic="true"
-      >
-        {wallet.status}
-      </p>
-      <button
-        type="button"
-        className="mt-6 inline-flex items-center justify-center rounded-full font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 px-4 py-2.5 text-sm border border-white/12 bg-white/6 text-slate-100 hover:border-cyan-200/30 hover:bg-white/10"
-      >
-        {actionLabel[wallet.connection]}
-      </button>
-    </article>
+      </CardHeader>
+      <CardBody className="mt-6">
+        <dl className="space-y-4">
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <dt id={securityId} className="text-slate-300 flex items-center gap-2">
+              Pending escrow
+              <Tooltip content="Time tokens held in escrow for active bookings. Released upon completion or cancellation." />
+            </dt>
+            <dd className="font-medium text-white">{wallet.pending}</dd>
+          </div>
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <dt className="text-slate-300 flex items-center gap-2">
+              Next payout
+              <Tooltip content="Scheduled release of earnings from completed time token transactions." />
+            </dt>
+            <dd className="font-medium text-white">{wallet.nextPayout}</dd>
+          </div>
+        </dl>
+        <p
+          id={statusId}
+          className="mt-6 text-sm text-cyan-100/75"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {wallet.status}
+        </p>
+      </CardBody>
+      <CardFooter className="mt-6">
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 px-4 py-2.5 text-sm border border-white/12 bg-white/6 text-slate-100 hover:border-cyan-200/30 hover:bg-white/10"
+        >
+          {actionLabel[wallet.connection]}
+        </button>
+      </CardFooter>
+    </Card>
   );
 }


### PR DESCRIPTION
This PR closes #103 

Description
This PR replaces inline-styled card components across the ChronoPay Dashboard with a reusable Card pattern. It introduces dedicated design tokens and classes under src/app/globals.css and a reusable <Card> React layout component (with layout slots <CardHeader>, <CardBody>, and <CardFooter>) to keep card surfaces, spacing, border styles, and hover/active states consistent and maintainable.

Key Changes
Design Tokens & CSS Styles: Added --radius-md, --radius-lg, --radius-xl, and --border variables under :root in 
globals.css
 and defined .card helper/variant classes.
Card Component: Created the new <Card> component in 
card.tsx
 supporting customizable wrapper elements (as), variants (variant="panel | glass | accent | default"), and custom states (interactive).

Refactoring & Migration:
MetricCard
WalletCard
QuickActions
StateCard
PanelShell
EmptyStateCard

Verification
Verified code compilation and module imports statically.
Ensured keyboard focus visibility, ARIA attributes, and semantic landmarks are preserved.
Clickable actions/cards respect touch targets and reduced motion preferences (prefers-reduced-motion).